### PR TITLE
feat: introduce layout regions

### DIFF
--- a/LAYOUT.md
+++ b/LAYOUT.md
@@ -1,0 +1,71 @@
+# C64Piano — Layout Description
+
+This describes **what goes where on the screen**, without code, CSS, or element names.
+
+---
+
+## Overall
+The screen is organized into **three vertical regions** with a small **control bar on top** and a **drum machine strip along the bottom**. The **left region** is for synthesis controls and visualizers, the **middle region** is for performance and editing, and the **right region** shows live **trackers**. Everything fits on one screen; only the trackers and editing grids scroll inside their own areas.
+
+---
+
+## Top Bar (always visible)
+- Shows: **Project** selector (if present), **Backend** selector (e.g., JS / WASM / MIDI), **Global Track Length**, **Quantize**, and **Load / Save / Save As** actions.
+- Provides **Play / Stop** transport on the right with a small status indicator.
+- **No instrument control here** (instrument lives in the FX view described below).
+
+---
+
+## Left Region (synthesis & visual feedback)
+From top to bottom:
+1. **Oscillator panel** with four waveform buttons (Pulse, Saw, Triangle, Noise) and a small waveform preview scope; includes pulse‑width and PWM rate controls when Pulse is selected.
+2. **ADSR panel** with an envelope preview scope and Attack/Decay/Sustain/Release controls.
+3. **Filter panel** with a response preview scope, mode buttons (Low‑pass, Band‑pass, High‑pass, Off), and Cutoff/Resonance controls.
+4. **Arpeggiator panel** with mode buttons (Off, Up, Down, Up/Down, Random) and Rate/Gate controls.
+
+These panels are compact and vertically stacked so they collectively occupy about the height of the middle region’s keyboard plus editor area.
+
+---
+
+## Middle Region (play + edit)
+Top to bottom:
+1. **Keyboard strip**: a compact on‑screen keyboard for auditioning notes and showing current octave/hotkeys.
+2. **Editing area with two tabs**:
+   - **Track Editor tab (default):** shows the note grid/pattern editor. This editor creates **tracks/patterns** that can be referenced by the trackers in the right region. The **Global Track Length** from the top bar sets the default length for this editor (you can still override per track if needed).
+   - **FX tab:** contains **Instrument selection** and **Instrument Load / Save / Save As** actions, plus the FX rack (Delay, Chorus, Bit/Crush, Drive). **All instrument management happens here**, not in the top bar.
+
+Switching tabs swaps only this middle editor view; the rest of the screen stays unchanged.
+
+---
+
+## Right Region (trackers, one tall pair)
+- Shows **two trackers side by side** that **span the full height** of this region (a “tall pair”). Each tracker displays notes **vertically** in time order.
+- Each tracker is labeled with its **Voice** and the **Track** it references, and shows the **effective length**.
+- Each tracker scrolls internally if the content exceeds the visible area.
+- A small action at the bottom allows **adding another voice** (additional voices can appear via paging or replacement, but the default visible configuration is two).
+
+The intention is that the **Track Editor** in the middle creates/edit tracks, and these trackers **play/reference** those tracks per voice.
+
+---
+
+## Bottom Drum Machine (full width of left + middle regions)
+- A wide strip aligned under the left and middle regions.
+- Header includes **Voice selection** (which synth voice will render drum events) and **Length** selection (16 / 32 / 64 steps).
+- The grid shows **four rows** (Kick, Snare, Hat, Tom) with step buttons across. It defaults to 16 or 32 visible steps but adapts to the selected length.
+- Interaction in this area is independent of the Track Editor length; the drum length is set by its own selector here.
+
+---
+
+## Behavior Notes
+- **Instrument management** (select, load, save) is **only** on the **FX** tab.
+- **Global Track Length** in the top bar applies to the **Track Editor** by default; the **Drum Machine** length is controlled in its own header.
+- **Trackers** show **notes vertically** and are intended to **reference** tracks made in the Track Editor.
+- Transport controls and any existing keyboard mappings continue to operate as before.
+
+---
+
+## Visual Priorities
+- Keep the left controls compact but readable, with small preview scopes for instant feedback.
+- The middle region’s keyboard is a short strip; most of the middle region height is reserved for editing.
+- The right region’s trackers should be the tallest elements to make vertical note flow readable.
+- The drum machine is prominent but shallow, optimized for quick step entry across four lanes.

--- a/index.html
+++ b/index.html
@@ -164,6 +164,18 @@
   @media (max-width: 980px){ :root{ --key-w:54px; --key-h:200px; } .drums{grid-template-columns:140px repeat(16,1fr)} }
   @media (max-width: 760px){ :root{ --key-w:46px; --key-h:180px; --black-w:32px; --black-h:116px; } .drums{grid-template-columns:110px repeat(16,1fr)} }
   @media (max-width: 560px){ :root{ --key-w:40px; --key-h:160px; --black-w:28px; --black-h:100px; } }
+
+  /* App layout */
+  #layout{display:grid; grid-template-columns:1fr 1fr 1fr; grid-template-rows:1fr auto; gap:20px;}
+  #leftRegion,#middleRegion,#rightRegion{display:flex; flex-direction:column; gap:12px;}
+  #drumMachineWrap{grid-column:1 / span 2;}
+  #topBar{margin-bottom:20px;}
+  #rightRegion{overflow:auto;}
+  #rightRegion .tracker{flex:1; border:2px solid var(--c64-border); border-radius:8px; padding:8px; overflow:auto;}
+  #rightRegion .tracker + .tracker{margin-top:12px;}
+  .tabBtns{display:flex; gap:6px; margin-bottom:8px;}
+  .tabContent{display:none;}
+  .tabContent.active{display:block;}
 </style>
 </head>
 <body>
@@ -180,17 +192,32 @@
 
 <div class="c64-window">
   <div class="c64-title">C64 PIANO / TRACKER</div>
-  <div class="block">
-  <div class="title">C64 Piano — Controls</div>
-  <!-- Engine toggle -->
-  <div class="row">
-    <div class="c64-seg" id="engineBtns" title="Select synth engine">
-      <button class="segBtn active" data-eng="js" aria-pressed="true">JS</button>
-      <button class="segBtn" data-eng="wasm">WASM</button>
+  <div id="topBar" class="block">
+    <div class="row">
+      <label>Project <select id="projectSel"></select></label>
+      <div class="c64-seg" id="engineBtns" title="Select synth engine">
+        <button class="segBtn active" data-eng="js" aria-pressed="true">JS</button>
+        <button class="segBtn" data-eng="wasm">WASM</button>
+      </div>
+      <label>Global Track Length <input id="globalTrackLen" type="number" min="1" value="16"></label>
+      <label>Quantize <input id="quantize" type="number" min="1" value="1"></label>
+      <button class="c64-btn" id="loadBtnTop">Load</button>
+      <button class="c64-btn" id="saveBtnTop">Save</button>
+      <button class="c64-btn" id="saveAsBtnTop">Save As</button>
+      <div class="transport" style="margin-left:auto">
+        <button class="c64-btn" id="transportPlay">Play</button>
+        <button class="c64-btn" id="transportStop">Stop</button>
+        <span class="pill" id="transportStatus">●</span>
+      </div>
     </div>
   </div>
 
-  <!-- Waveform controls: buttons + presets + visual -->
+  <div id="layout">
+    <div id="leftRegion">
+      <div class="block">
+        <div class="title">C64 Piano — Controls</div>
+    <!-- Engine toggle moved to top bar -->
+    <!-- Waveform controls: buttons + presets + visual -->
   <div class="row">
     <div class="c64-seg" id="waveBtns" title="Select waveform">
       <button class="segBtn active" data-wave="pulse" aria-pressed="true" title="Pulse (square)">
@@ -282,9 +309,10 @@
   </div>
 
   <div class="note">Keys: A S D F G H J K (white) and W E T Y U (black). Octave with , and . (display shows &lt; / &gt;).</div>
-  </div>
-
-  <div class="block">
+      </div>
+    </div>
+    <div id="middleRegion">
+      <div class="block">
   <div class="title">C64 Piano — Keyboard</div>
   <div class="kbdWrap">
     <div class="kbd" id="kbd">
@@ -310,7 +338,6 @@
           <button class="c64-btn" id="voicePrev" title="Previous voice">◀</button>
           <span class="pill" id="voiceDisp">1</span>
           <button class="c64-btn" id="voiceNext" title="Next voice">▶</button>
-          <button class="c64-btn" id="addVoiceBtn" title="Add voice">＋</button>
           <label style="display:flex;align-items:center;gap:4px">Track
             <select id="patternSel"></select>
           </label>
@@ -324,9 +351,21 @@
       <div class="histList" id="histList" aria-live="polite"></div>
     </div>
   </div>
-</div>
-
-  <div class="block">
+      </div>
+    </div>
+    <div id="rightRegion">
+      <div class="block tracker">
+        <div class="title">Voice 1</div>
+        <div id="tracker1"></div>
+      </div>
+      <div class="block tracker">
+        <div class="title">Voice 2</div>
+        <div id="tracker2"></div>
+      </div>
+      <button class="c64-btn" id="addVoiceBtn" title="Add voice">＋</button>
+    </div>
+    <div id="drumMachineWrap">
+      <div class="block">
   <div class="title">C64‑style Drum Machine</div>
   <div class="drums" id="drums"></div>
   <div class="transport">
@@ -335,8 +374,9 @@
     <label title="Beats per minute. 16th notes are steps.">Tempo <input id="bpm" type="range" min="60" max="180" step="1" value="120"></label>
     <span style="font-size:12px;opacity:.9">Trigger now: Z/X/C/V</span>
   </div>
-</div>
-
+      </div>
+    </div>
+  </div>
 </div>
 
 <script>


### PR DESCRIPTION
## Summary
- add top bar with project, backend, track length, and transport controls
- split page into left controls, middle keyboard/editor, right tracker column, and bottom drum machine

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be2f3d05c483289fe99b743474aa96