### PR TITLE
Ensure cross-origin isolation headers for navigations

### DIFF
--- a/index.html
+++ b/index.html
@@ -539,6 +539,14 @@
 const AudioContext = window.AudioContext || window.webkitAudioContext;
 const ctx = new AudioContext({ latencyHint: 'interactive' });
 let audioReady=false;
+if ('serviceWorker' in navigator){
+  let reloadingForCOI=false;
+  navigator.serviceWorker.addEventListener('controllerchange', ()=>{
+    if(reloadingForCOI || window.crossOriginIsolated) return;
+    reloadingForCOI=true;
+    window.location.reload();
+  });
+}
 async function unlockAudio(){
   if(audioReady) return;
   try{


### PR DESCRIPTION
## Summary
- add COOP/COEP/CORP headers to navigation responses served by the service worker
- reload the document once when a new service worker controller takes over so the navigation is isolated

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c88578a1388328afe9493b3f483c79