### PR TITLE
Add service worker for cross-origin isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,12 @@ Current version: 0.4.0
 
 ## Development Notes
 
-The default hybrid and JavaScript engines run entirely in WebAudio, so no service worker or cross-origin isolation headers are required. The optional webSID mode embeds Tiny'R'Sid inside an AudioWorklet and therefore needs cross-origin isolation to run; when unavailable, the app automatically falls back to the hybrid or JS engines. Audio still unlocks on the first user interaction to comply with browser autoplay policies.
+The optional webSID engine runs inside an AudioWorklet and therefore needs the page to be [cross-origin isolated](https://developer.mozilla.org/docs/Web/API/crossOriginIsolated). The bundled service worker (`service-worker.js`) rewrites navigation and worker responses so they always include the required headers:
+
+- `Cross-Origin-Opener-Policy: same-origin`
+- `Cross-Origin-Embedder-Policy: require-corp`
+
+The registration code in `index.html` reloads the tab the first time the service worker becomes the active controller, ensuring those headers are present on the main document. Serve the project over HTTP(S) (for example, `python -m http.server`) so the service worker can install—`file://` URLs skip registration. After the reload, choosing **webSID Engine** runs the AudioWorklet without falling back to the hybrid synth. Audio still unlocks on the first user interaction to comply with browser autoplay policies.
 
 ## Verification Checklist
 

--- a/index.html
+++ b/index.html
@@ -531,6 +531,24 @@
 </div>
 
 <script>
+// === Service worker & cross-origin isolation ===
+if ('serviceWorker' in navigator && window.location.protocol !== 'file:') {
+  let reloadedForIsolation = false;
+  navigator.serviceWorker.register('service-worker.js', { scope: './' })
+    .then(() => {
+      if (!navigator.serviceWorker.controller) {
+        navigator.serviceWorker.addEventListener('controllerchange', () => {
+          if (reloadedForIsolation) return;
+          reloadedForIsolation = true;
+          window.location.reload();
+        });
+      }
+    })
+    .catch((err) => {
+      console.warn('Service worker registration failed', err);
+    });
+}
+
 // === Audio setup ===
 const AudioContext = window.AudioContext || window.webkitAudioContext;
 const ctx = new AudioContext({ latencyHint: 'interactive' });

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,44 @@
+const COOP_VALUE = 'same-origin';
+const COEP_VALUE = 'require-corp';
+const ISOLATION_HEADERS = [
+  ['Cross-Origin-Opener-Policy', COOP_VALUE],
+  ['Cross-Origin-Embedder-Policy', COEP_VALUE]
+];
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+async function withIsolationHeaders(request) {
+  const response = await fetch(request);
+  const headers = new Headers(response.headers);
+  for (const [key, value] of ISOLATION_HEADERS) {
+    headers.set(key, value);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers
+  });
+}
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  const destination = request.destination;
+  if (request.mode === 'navigate' || destination === 'document' ||
+      destination === 'worker' || destination === 'sharedworker' ||
+      destination === 'audioworklet') {
+    event.respondWith((async () => {
+      try {
+        return await withIsolationHeaders(request);
+      } catch (err) {
+        console.error('Failed to apply COOP/COEP headers', err);
+        return fetch(request);
+      }
+    })());
+  }
+});


### PR DESCRIPTION
## Summary
- register a service worker on page load so navigation responses include COOP/COEP headers and automatically reload when the worker first controls the page
- add a service worker that rewrites navigation and worker requests with `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`
- document the new headers and service-worker flow in the Development Notes section of the README

## Testing
- python3 - <<'PY'
import asyncio
from playwright.async_api import async_playwright

async def main():
    async with async_playwright() as p:
        browser = await p.chromium.launch()
        page = await browser.new_page()
        console_messages = []
        page.on('console', lambda msg: console_messages.append(f"{msg.type}: {msg.text}"))
        await page.goto('http://127.0.0.1:8000/', wait_until='networkidle')
        await page.wait_for_function('window.crossOriginIsolated === true', timeout=20000)
        await page.wait_for_selector('#engineSel')
        await page.select_option('#engineSel', 'websid')
        await page.wait_for_timeout(2000)
        select_value = await page.eval_on_selector('#engineSel', 'el => el.value')
        iso = await page.evaluate('window.crossOriginIsolated')
        print('crossOriginIsolated:', iso)
        print('engineSelectValue:', select_value)
        fallback_logs = [msg for msg in console_messages if 'Using Hybrid' in msg or 'falling back' in msg]
        print('fallbackLogCount:', len(fallback_logs))
        for msg in fallback_logs:
            print('fallbackLog:', msg)
        await browser.close()

asyncio.run(main())
PY

------
https://chatgpt.com/codex/tasks/task_e_68c988c48b2c83289826e0af4d5837bf