### PR TITLE
Ensure cross-origin isolation headers and webSID preference persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -2000,7 +2000,12 @@ async function setEngine(id, {persist=false}={}){
       showBanner('webSID engine requires cross-origin isolation. Using Hybrid.');
       if(engineSel) engineSel.value=state.engine;
       if(persist){
-        try{ localStorage.setItem(ENGINE_STORAGE_KEY, state.engine); }
+        const canAwaitIsolation =
+          window.location.protocol !== 'file:' &&
+          window.isSecureContext &&
+          'serviceWorker' in navigator;
+        const storageValue = canAwaitIsolation ? 'websid' : state.engine;
+        try{ localStorage.setItem(ENGINE_STORAGE_KEY, storageValue); }
         catch(e){ }
       }
       return state.engine;

--- a/service-worker.js
+++ b/service-worker.js
@@ -2,7 +2,8 @@ const COOP_VALUE = 'same-origin';
 const COEP_VALUE = 'require-corp';
 const ISOLATION_HEADERS = [
   ['Cross-Origin-Opener-Policy', COOP_VALUE],
-  ['Cross-Origin-Embedder-Policy', COEP_VALUE]
+  ['Cross-Origin-Embedder-Policy', COEP_VALUE],
+  ['Origin-Agent-Cluster', '?1']
 ];
 
 self.addEventListener('install', (event) => {


### PR DESCRIPTION
## Summary
- add the Origin-Agent-Cluster response header from the service worker so Chromium fully isolates the page
- keep the persisted engine preference set to webSID while isolation is still pending in secure, service-worker-enabled contexts

## Testing
- no automated tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9a609db548328bd6d1ee1b0980c8d